### PR TITLE
Fix for float32 != float64 numpy array incompatibility (training with cpu)

### DIFF
--- a/train.py
+++ b/train.py
@@ -81,7 +81,7 @@ if args.gpu >= 0:
     for key, value in state.items():
         value.data = cuda.to_gpu(value.data)
 else:
-    accum_loss   = Variable(np.zeros(()))
+    accum_loss   = Variable(np.zeros((), dtype=np.float32))
 
 print 'going to train {} iterations'.format(jump * n_epochs)
 for i in xrange(jump * n_epochs):
@@ -108,7 +108,7 @@ for i in xrange(jump * n_epochs):
         if args.gpu >= 0:
             accum_loss = Variable(cuda.zeros(()))
         else:
-            accum_loss = Variable(np.zeros(()))
+            accum_loss = Variable(np.zeros((), dtype=np.float32))
 
         optimizer.clip_grads(grad_clip)
         optimizer.update()


### PR DESCRIPTION
By default, numpy arrays were float64, which are incompatible with chainer. Simple fix to force dtype to float32.
