### PR TITLE
Bugfix to GPU argument

### DIFF
--- a/train.py
+++ b/train.py
@@ -90,7 +90,7 @@ for i in xrange(jump * n_epochs):
     y_batch = np.array([train_data[(jump * j + i + 1) % whole_len]
                         for j in xrange(batchsize)])
 
-    if args.gpu >=0:
+    if args.gpu > 0:
         x_batch = cuda.to_gpu(x_batch)
         y_batch = cuda.to_gpu(y_batch)
 


### PR DESCRIPTION
If gpu argument is set to 0, it still attempts to run with CUDA on as the test was for >= rather than just >. To get this code to run without CUDA at present i had to do --gpu -1.
